### PR TITLE
Startup fixes

### DIFF
--- a/AppleWirelessKeyboardCore/Services/SettingsService.cs
+++ b/AppleWirelessKeyboardCore/Services/SettingsService.cs
@@ -12,7 +12,7 @@ namespace AppleWirelessKeyboardCore.Services
 {
     public class SettingsService
     {
-        public static SettingsService Default { get; set; } = Load().Result;
+        public static SettingsService Default { get; set; } = Load();
 
         public event EventHandler? LanguageChanged;
 
@@ -59,12 +59,12 @@ namespace AppleWirelessKeyboardCore.Services
             }
         }
 
-        public static async Task<SettingsService> Load()
+        public static SettingsService Load()
         {
             try
             {
                 var path = GetStorageFileLocation();
-                var text = await File.ReadAllTextAsync(path);
+                var text = File.ReadAllText(path);
                 return JsonSerializer.Deserialize<SettingsService>(text) ?? new SettingsService();
             }
             catch (Exception ex)

--- a/AppleWirelessKeyboardCore/Services/StartupShortcutService.cs
+++ b/AppleWirelessKeyboardCore/Services/StartupShortcutService.cs
@@ -15,8 +15,9 @@ namespace AppleWirelessKeyboardCore.Views
         public static void Register()
         {
             var rk = Registry.CurrentUser.OpenSubKey(REGISTRY_RUN_KEY, true);
-            rk?.SetValue(REGISTRY_RUN_VALUENAME,
-                Assembly.GetExecutingAssembly().Location.Remove(0, 8).Replace("/", "\\"));
+            var shortcut = GetShortcutPath();
+            if(shortcut != null)
+                rk?.SetValue(REGISTRY_RUN_VALUENAME, shortcut);
         }
 
         public static void UnRegister()
@@ -25,10 +26,9 @@ namespace AppleWirelessKeyboardCore.Views
             rk?.DeleteValue(REGISTRY_RUN_VALUENAME);
         }
 
-        private static string GetShortcutPath()
+        private static string? GetShortcutPath()
         {
-            string folder = Environment.GetFolderPath(Environment.SpecialFolder.Startup);
-            return Path.Combine(folder, Assembly.GetEntryAssembly()?.GetName()?.Name ?? "");
+            return System.Diagnostics.Process.GetCurrentProcess().MainModule?.FileName;
         }
 
         public static bool IsRegistered


### PR DESCRIPTION
The first commit fixes an issue where I found it was consistently hanging on startup if the config file was present. Making the load synchronous seemed to resolve it.

The second commit updates the unused GetShortcutPath function so it finds the correct path for the executable, and updates the Register() function to use it (partial fix for #42)

Several more fixes to come if you're happy to merge!