### PR TITLE
Fix settings save bugs (resolves #51, #45, #42, #15)

### DIFF
--- a/AppleWirelessKeyboardCore/App.xaml.cs
+++ b/AppleWirelessKeyboardCore/App.xaml.cs
@@ -31,10 +31,10 @@ namespace AppleWirelessKeyboardCore
             }
         }
 
-        private async void Application_Exit(object sender, ExitEventArgs e)
+        private void Application_Exit(object sender, ExitEventArgs e)
         {
             TrayIconService.Close();
-            await SettingsService.Default.SaveAsync();
+            SettingsService.Default.Save();
         }
     }
 }

--- a/AppleWirelessKeyboardCore/Services/SettingsService.cs
+++ b/AppleWirelessKeyboardCore/Services/SettingsService.cs
@@ -45,13 +45,16 @@ namespace AppleWirelessKeyboardCore.Services
         private static string GetStorageFileLocation() =>
             Path.Combine(GetStorageFolderLocation(), "settings.json");
 
-        public async Task SaveAsync()
+        public void Save()
         {
+            var text = "";
             try
             {
                 Directory.CreateDirectory(GetStorageFolderLocation());
-                using var stream = File.OpenWrite(GetStorageFileLocation());
-                await JsonSerializer.SerializeAsync(stream, this);
+                var opts = new JsonSerializerOptions();
+                opts.WriteIndented = true;
+                text = JsonSerializer.Serialize<SettingsService>(this, opts);
+                File.WriteAllText(GetStorageFileLocation(), text);
             }
             catch (Exception ex)
             {
@@ -61,11 +64,12 @@ namespace AppleWirelessKeyboardCore.Services
 
         public static SettingsService Load()
         {
+            var text = "";
             try
             {
-                var path = GetStorageFileLocation();
-                var text = File.ReadAllText(path);
-                return JsonSerializer.Deserialize<SettingsService>(text) ?? new SettingsService();
+                text = File.ReadAllText(GetStorageFileLocation());
+                var settings = JsonSerializer.Deserialize<SettingsService>(text);
+                return settings ?? new SettingsService();
             }
             catch (Exception ex)
             {

--- a/AppleWirelessKeyboardCore/Views/Configuration.xaml
+++ b/AppleWirelessKeyboardCore/Views/Configuration.xaml
@@ -128,7 +128,7 @@
             <TabItem Header="{Binding Path=Bindings, Source={x:Static srv:TranslationService.Default}}">
                 <DataGrid Name="grdBindings" AutoGenerateColumns="False" CanUserAddRows="True" CanUserDeleteRows="True"
                           CanUserReorderColumns="True" CanUserResizeColumns="True" CanUserResizeRows="False"
-                          CanUserSortColumns="True" RowStyle="{StaticResource DefaultRowStyle}">
+                          CanUserSortColumns="True" RowStyle="{StaticResource DefaultRowStyle}" Unloaded="grdBindings_Unloaded">
                     <DataGrid.Columns>
                         <DataGridComboBoxColumn x:Name="clmnKey" Header="{Binding Path=Key, Source={x:Static srv:TranslationService.Default}}"
                                                 SelectedItemBinding="{Binding Key}" />

--- a/AppleWirelessKeyboardCore/Views/Configuration.xaml.cs
+++ b/AppleWirelessKeyboardCore/Views/Configuration.xaml.cs
@@ -49,10 +49,10 @@ namespace AppleWirelessKeyboardCore.Views
             cmbLanguage.SelectedItem = SettingsService.Default.ActiveLanguage;
         }
 
-        private async void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)
+        private void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)
         {
-            grdBindings.CancelEdit();
-            await SettingsService.Default.SaveAsync();
+            grdBindings.CommitEdit(DataGridEditingUnit.Row, true);
+            SettingsService.Default.Save();
             StartupShortcutService.Check();
         }
 
@@ -65,7 +65,7 @@ namespace AppleWirelessKeyboardCore.Views
             }
         }
 
-        private async void btnFactoryReset_Click(object sender, RoutedEventArgs e)
+        private void btnFactoryReset_Click(object sender, RoutedEventArgs e)
         {
             if (MessageBoxResult.Yes == MessageBox.Show("Are you sure you want to replace your key bindings to the defaults?", "Reset Bindings", MessageBoxButton.YesNo))
             {
@@ -91,8 +91,14 @@ namespace AppleWirelessKeyboardCore.Views
                     Module = nameof(VolumeControl.VolumeMute)
                 });
                
-                await SettingsService.Default.SaveAsync();
+                SettingsService.Default.Save();
             }
+        }
+
+        private void grdBindings_Unloaded(object sender, RoutedEventArgs e)
+        {
+            var grid = (DataGrid)sender;
+            grid.CommitEdit(DataGridEditingUnit.Row, true);
         }
     }
 }


### PR DESCRIPTION
- File.OpenWrite was not truncating
- Async operation sometimes wrote 0 bytes
- Fix DeferRefresh exception when switching config tabs
- Committed grid edits instead of cancelling them
- Pretty-printed JSON, just because
- Resolves #51
- Resolves #45
- Resolves #42 
- Resolves #15