### PR TITLE
Update .Net version to the latest one ,Net 6

### DIFF
--- a/AppleWirelessKeyboardCore/AppleWirelessKeyboardCore.csproj
+++ b/AppleWirelessKeyboardCore/AppleWirelessKeyboardCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
 	<PublishSingleFile>true</PublishSingleFile>
 	<SelfContained>false</SelfContained>
     <UseWPF>true</UseWPF>


### PR DESCRIPTION
Currently, AppleWirelessKeyboard does not work without installing an outdated .Net 5.0 runtime.